### PR TITLE
Fixes + enable extra mpv features 

### DIFF
--- a/io.mpv.Mpv.yml
+++ b/io.mpv.Mpv.yml
@@ -98,6 +98,154 @@ modules:
     url: https://linuxtv.org/downloads/v4l-utils/v4l-utils-1.20.0.tar.bz2
     sha256: 956118713f7ccb405c55c7088a6a2490c32d54300dd9a30d8d5008c28d3726f7
 
+- name: libcdio
+  config-opts:
+    - --disable-static
+    - --disable-example-progs
+  cleanup:
+    - /include
+    - /lib/*.a
+    - /lib/pkgconfig
+  sources:
+    - type: archive
+      url: https://ftp.gnu.org/gnu/libcdio/libcdio-2.1.0.tar.bz2
+      sha256: 8550e9589dbd594bfac93b81ecf129b1dc9d0d51e90f9696f1b2f9b2af32712b
+      x-checker-data:
+        type: html
+        url: https://ftp.gnu.org/gnu/libcdio/
+        version-pattern: libcdio-(\d\.\d+\.?\d*).tar.bz2
+        url-template: https://ftp.gnu.org/gnu/libcdio/libcdio-$version.tar.bz2
+
+- name: libcdio-paranoia
+  config-opts:
+    - --disable-static
+    - --disable-example-progs
+  cleanup:
+    - /include
+    - /lib/*.a
+    - /lib/pkgconfig
+  sources:
+    - type: archive
+      url: https://ftp.gnu.org/gnu/libcdio/libcdio-paranoia-10.2+2.0.1.tar.bz2
+      sha256: 33b1cf305ccfbfd03b43936975615000ce538b119989c4bec469577570b60e8a
+      x-checker-data:
+        type: html
+        url: https://ftp.gnu.org/gnu/libcdio/
+        version-pattern: libcdio-paranoia-([\d\.\+-]+).tar.bz2
+        url-template: https://ftp.gnu.org/gnu/libcdio/libcdio-paranoia-$version.tar.bz2
+
+- name: libdvdread
+  config-opts:
+    - --disable-static
+  cleanup:
+    - /include
+    - /lib/*.a
+    - /lib/pkgconfig
+  sources:
+    - type: archive
+      url: https://download.videolan.org/pub/videolan/libdvdread/6.1.1/libdvdread-6.1.1.tar.bz2
+      sha256: 3e357309a17c5be3731385b9eabda6b7e3fa010f46022a06f104553bf8e21796
+      x-checker-data:
+        type: html
+        url: https://www.videolan.org/developers/libdvdnav.html
+        version-pattern: "The latest version of <code>libdvdread</code> is <b>(\\d\\.\\d+\\.?\\d*)</b>\\."
+        url-template: https://download.videolan.org/pub/videolan/libdvdread/$version/libdvdread-$version.tar.bz2
+
+- name: libdvdnav
+  config-opts:
+    - --disable-static
+  cleanup:
+    - /include
+    - /lib/*.a
+    - /lib/pkgconfig
+  sources:
+    - type: archive
+      url: https://download.videolan.org/pub/videolan/libdvdnav/6.1.1/libdvdnav-6.1.1.tar.bz2
+      sha256: c191a7475947d323ff7680cf92c0fb1be8237701885f37656c64d04e98d18d48
+      x-checker-data:
+        type: html
+        url: https://www.videolan.org/developers/libdvdnav.html
+        version-pattern: "The latest version of <code>libdvdnav</code> is <b>(\\d\\.\\d+\\.?\\d*)</b>\\."
+        url-template: https://download.videolan.org/pub/videolan/libdvdnav/$version/libdvdnav-$version.tar.bz2
+
+- name: libbluray
+  config-opts:
+    - --disable-static
+    - --disable-bdjava-jar
+  cleanup:
+    - /include
+    - /lib/*.a
+    - /lib/pkgconfig
+  sources:
+    - sha256: e2dbaf99e84e0a9725f4985bcb85d41e52c2261cc651d8884b1b790b5ef016f9
+      type: archive
+      url: https://download.videolan.org/pub/videolan/libbluray/1.3.0/libbluray-1.3.0.tar.bz2
+      x-checker-data:
+        type: html
+        url: https://www.videolan.org/developers/libbluray.html
+        version-pattern: "Latest release is <b>libbluray (\\d\\.\\d+\\.?\\d*)</b>\\."
+        url-template: https://download.videolan.org/pub/videolan/libbluray/$version/libbluray-$version.tar.bz2
+
+- name: zimg
+  config-opts:
+    - --disable-static
+  cleanup:
+    - /include
+    - /lib/*.a
+    - /lib/pkgconfig
+    - /share/doc
+  sources:
+    - type: archive
+      archive-type: tar
+      url: https://api.github.com/repos/sekrit-twc/zimg/tarball/release-3.0.1
+      sha256: 26f067e28df30dc8f5ddd08dfaf6795e27aae5e1e644b620889d4da92e6ceefd
+      x-checker-data:
+        type: json
+        url: https://api.github.com/repos/sekrit-twc/zimg/releases/latest
+        url-query: .tarball_url
+        version-query: .tag_name | sub("^release-"; "")
+        timestamp-query: .published_at
+
+- name: rubberband
+  buildsystem: meson
+  cleanup:
+    - /include
+    - /lib/*.a
+    - /lib/pkgconfig
+  sources:
+    - type: archive
+      url: https://breakfastquay.com/files/releases/rubberband-1.9.2.tar.bz2
+      sha256: b3cff5968517141fcf9e1ef6b5a1fdb06a5511f148000609216cf182ff4ab612
+      x-checker-data:
+        type: html
+        url: https://www.breakfastquay.com/rubberband/
+        version-pattern: "Rubber Band Library v(\\d\\.\\d+\\.?\\d*) source"
+        url-template: https://breakfastquay.com/files/releases/rubberband-$version.tar.bz2
+
+- name: mujs
+  no-autogen: true
+  make-args:
+    - release
+    - shared
+  make-install-args:
+    - prefix=/app
+    - install-shared
+  cleanup:
+    - /bin
+    - /include
+    - /lib/*.a
+    - /lib/pkgconfig
+  sources:
+    - type: archive
+      archive-type: tar
+      url: https://api.github.com/repos/ccxvii/mujs/tarball/refs/tags/1.1.3
+      sha256: d5f614a6190f8e00a8fcc4d773e52a836fc2755d535332557f5f805f9ffec598
+      x-checker-data:
+        type: json
+        url: https://api.github.com/repos/ccxvii/mujs/tags
+        url-query: .[0].tarball_url
+        version-query: .[0].name
+
       
 - name: nv-codec-headers
   cleanup:
@@ -124,6 +272,7 @@ modules:
   - --disable-static
   - --disable-debug        
   - --disable-doc
+  - --disable-programs
   - --enable-gnutls  
   - --enable-shared    
   - --enable-encoder=png
@@ -153,10 +302,13 @@ modules:
   - python3 waf configure --prefix=/app 
                           --enable-libmpv-shared 
                           --disable-build-date 
+                          --disable-manpage-build
                           --disable-alsa
-                          --enable-libmpv-shared 
                           --enable-sdl2 
                           --enable-libarchive 
+                          --enable-dvbin
+                          --enable-cdda
+                          --enable-dvdnav
   - python3 waf build
   - python3 waf install
   post-install:

--- a/io.mpv.Mpv.yml
+++ b/io.mpv.Mpv.yml
@@ -33,9 +33,10 @@ modules:
   - /lib/pkgconfig
   - /share/man
   sources:
-  - type: archive
-    url: http://luajit.org/download/LuaJIT-2.1.0-beta3.tar.gz
-    sha256: 1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3
+  - type: git
+    url: https://luajit.org/git/luajit-2.0.git
+    branch: v2.1
+    disable-shallow-clone: true
   - type: shell
     commands:
     - sed -i 's|/usr/local|/app|' ./Makefile

--- a/io.mpv.Mpv.yml
+++ b/io.mpv.Mpv.yml
@@ -129,9 +129,7 @@ modules:
   - --enable-libv4l2
   - --enable-gpl
   - --enable-version3    
-  - --enable-nonfree     
   - --enable-libass      
-  - --enable-libfdk-aac  
   - --enable-libfreetype 
   - --enable-libmp3lame  
   - --enable-libopus     


### PR DESCRIPTION
- Remove `--enable-nonfree` ffmpeg build. This is not redistributable.
  - Remove incompatible and unused `--enable-libfdk-aac` option.
- Switch luajit source to versioned branch as recommended by luajit upstream
- Add dependencies to enable mpv features.

What's missing:
- vapoursynth
  - Best done by someone who can test this.
- vulkan + libplacebo
  - Some deps require a new runtime
- libsixel
  - To be done on next libsixel release