### PR TITLE
Revert "enabled g,y forward/backward subtitle shortcuts"

### DIFF
--- a/io.mpv.Mpv.yml
+++ b/io.mpv.Mpv.yml
@@ -327,10 +327,6 @@ modules:
       # Remove this and above 3 lines after new release of mpv > v0.33.1
       
       
-  # y and g Step forward/backward in the subtitle list
-      - mkdir -p /app/etc/mpv/
-      - echo 'y sub-step +1'  > /app/etc/mpv/input.conf
-      - echo 'g sub-step -1' >> /app/etc/mpv/input.conf
   # save screenshots at ~/Pictures/mpv-screenshots
       - echo "screenshot-directory=~/Pictures/mpv-screenshots" > /app/etc/mpv/mpv.conf
     sources:


### PR DESCRIPTION
This reverts commit 2cec20a464d8907529272b9276507ae28f4a8624.

That commit forced hard-coded non-default input bindings upon all users of this Flatpak package, which is a really bad and unexpected thing.

Imagine the user's surprise when they hit these cases despite `no-input-default-bindings`. This violates the principle of least surprise, and there's really no reason this needs to be done in this Flatpak...