### PR TITLE
Update mpv_inhibit_gnome to 0.1.2

### DIFF
--- a/io.mpv.Mpv.yml
+++ b/io.mpv.Mpv.yml
@@ -686,5 +686,5 @@ modules:
       - install -D lib/mpv_inhibit_gnome.so /app/etc/mpv/scripts
     sources:
       - type: archive
-        url: https://github.com/Guldoman/mpv_inhibit_gnome/archive/refs/tags/v0.1.0.tar.gz
-        sha256: 94f4e65eeecfaf0c75318948ee0862bb4d42b22f61eb55b3bd7396fe14746adb
+        url: https://github.com/Guldoman/mpv_inhibit_gnome/archive/refs/tags/v0.1.2.tar.gz
+        sha256: 080304d77d2e8d63b1af71ac60dc90718b1a812b7281f8c24554b9a276ef7f41


### PR DESCRIPTION
The updated version links correctly to `libdbus`. Fixes #94.