### PR TITLE
Enable Bauer stereophonic-to-binaural DSP on ffmpeg.

### DIFF
--- a/io.mpv.Mpv.yml
+++ b/io.mpv.Mpv.yml
@@ -337,6 +337,7 @@ modules:
         sha256: a8a8cbf7b0b2508a6932278799b9bf5c63d833d9e7d651aea4622f3bc6b992aa
 
   - name: libbs2b
+    buildsystem: autotools
     config-opts:
       - --disable-static
     cleanup:
@@ -347,6 +348,11 @@ modules:
         archive-type: tar
         url: https://downloads.sourceforge.net/sourceforge/bs2b/libbs2b-3.1.0.tar.gz
         sha256: 6aaafd81aae3898ee40148dd1349aab348db9bfae9767d0e66e0b07ddd4b2528
+      # https://src.fedoraproject.org/rpms/libbs2b/blob/rawhide/f/libbs2b.spec#_40
+      - type: shell
+        commands:
+         - sed -i -e 's/lzma/xz/g' configure.ac
+         - autoreconf -vif
 
   - name: ffmpeg
     cleanup:

--- a/io.mpv.Mpv.yml
+++ b/io.mpv.Mpv.yml
@@ -336,6 +336,18 @@ modules:
         url: https://github.com/hoene/libmysofa/archive/refs/tags/v1.3.1.tar.gz
         sha256: a8a8cbf7b0b2508a6932278799b9bf5c63d833d9e7d651aea4622f3bc6b992aa
 
+  - name: libbs2b
+    config-opts:
+      - --disable-static
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: archive
+        archive-type: tar
+        url: https://downloads.sourceforge.net/sourceforge/bs2b/libbs2b-3.1.0.tar.gz
+        sha256: 6aaafd81aae3898ee40148dd1349aab348db9bfae9767d0e66e0b07ddd4b2528
+
   - name: ffmpeg
     cleanup:
       - /include
@@ -364,6 +376,7 @@ modules:
       - --enable-libx264
       - --enable-libx265
       - --enable-libmysofa
+      - --enable-libbs2b
 
     sources:
       - type: archive


### PR DESCRIPTION
This pull request enables [bs2b](https://bs2b.sourceforge.net/) on ffmpeg, which allows mpv to access it through the [audio filters option](https://mpv.io/manual/master/#options-af).

[The Bauer stereophonic-to-binaural DSP (bs2b) is designed to improve headphone listening of stereo audio records.](https://bs2b.sourceforge.net/)

Can be used with mpv by adding the [`--af=bs2b` option](https://mpv.io/manual/master/#audio-filters).

[Ffmpeg bs2b documentation.](https://ffmpeg.org/ffmpeg-filters.html#bs2b)

Additional information : https://hhsprings.bitbucket.io/docs/programming/examples/ffmpeg/manipulating_audio/bs2b.html