### PR TITLE
Downgrade yt-dlp play audio

### DIFF
--- a/io.mpv.Mpv.yml
+++ b/io.mpv.Mpv.yml
@@ -98,13 +98,13 @@ modules:
       - install yt-dlp /app/bin
     sources:
       - type: archive
-        url: https://github.com/yt-dlp/yt-dlp/releases/download/2023.03.04/yt-dlp.tar.gz
-        sha256: 771d2abefcd5f1e6f3ab6d6d18cdae98be4ab73538d1174e7e7236640418e150
-        x-checker-data:
-          type: json
-          url: https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest
-          version-query: .tag_name
-          url-query: .assets[] | select(.name=="yt-dlp.tar.gz") | .browser_download_url
+        url: https://github.com/yt-dlp/yt-dlp/releases/download/2023.02.17/yt-dlp.tar.gz
+        sha256: 81f607b8754b1bc67e6592a4e316c015d720e7118757a5afd4ef2aaf37d2ef29
+        #x-checker-data:
+        #  type: json
+        #  url: https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest
+        #  version-query: .tag_name
+        #  url-query: .assets[] | select(.name=="yt-dlp.tar.gz") | .browser_download_url
 
   - name: uchardet
     buildsystem: cmake-ninja


### PR DESCRIPTION
https://github.com/flathub/io.mpv.Mpv/issues/159

disabled x-data-checker, till yt-dlp releases a fixed version which can play both audio and video from youtube.