### PR TITLE
Re-enable external data checker for yt-dlp

### DIFF
--- a/io.mpv.Mpv.yml
+++ b/io.mpv.Mpv.yml
@@ -100,11 +100,11 @@ modules:
       - type: archive
         url: https://github.com/yt-dlp/yt-dlp/releases/download/2023.02.17/yt-dlp.tar.gz
         sha256: 81f607b8754b1bc67e6592a4e316c015d720e7118757a5afd4ef2aaf37d2ef29
-        #x-checker-data:
-        #  type: json
-        #  url: https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest
-        #  version-query: .tag_name
-        #  url-query: .assets[] | select(.name=="yt-dlp.tar.gz") | .browser_download_url
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest
+          version-query: .tag_name
+          url-query: .assets[] | select(.name=="yt-dlp.tar.gz") | .browser_download_url
 
   - name: uchardet
     buildsystem: cmake-ninja


### PR DESCRIPTION
The external data checker was disabled in commit 3fdef98 because of mpv issue https://github.com/mpv-player/mpv/issues/11392, which was fixed in mpv 0.36.0.