### PR TITLE
Build ffmpeg programs

### DIFF
--- a/io.mpv.Mpv.yml
+++ b/io.mpv.Mpv.yml
@@ -444,7 +444,6 @@ modules:
     config-opts:
       - --disable-debug
       - --disable-doc
-      - --disable-programs
       - --disable-static
       - --enable-encoder=png
       - --enable-gnutls


### PR DESCRIPTION
`yt-dlp` occasionally uses the `ffmpeg` binary, but since it is not build for the ffmpeg installation in `/app`, it uses the binary from the freedeskop runtime. This is undesirable, because this binary was built against older library versions, but when called, it partially uses the newer shared libraries in `/app/lib`. This is detected by `ffmpeg` and leads to the warning message:

`WARNING: library configuration mismatch`