### PR TITLE
Save screenshots to xdg-pictures/mpv

### DIFF
--- a/io.mpv.Mpv.yml
+++ b/io.mpv.Mpv.yml
@@ -590,8 +590,9 @@ modules:
       - /include
       - /lib/pkgconfig
     post-install:
-      # save screenshots at ~/Pictures/mpv
-      - echo "screenshot-directory=~/Pictures/mpv" > /app/etc/mpv/mpv.conf
+      - mv /app/bin/mpv /app/bin/mpv-bin
+      # save screenshots at xdg-pictures/mpv
+      - echo "screenshot-directory=~/.var/app/io.mpv.Mpv/Pictures/mpv" > /app/etc/mpv/mpv.conf
     sources:
       - type: git
         url: https://github.com/mpv-player/mpv.git
@@ -616,6 +617,14 @@ modules:
           - chmod 644 /app/share/appdata/$FLATPAK_ID.appdata.xml
 
 # Scripts for mpv
+  - name: mpv-wrapper
+    buildsystem: simple
+    build-commands:
+      - install -D mpv /app/bin/mpv
+    sources:
+      - type: file
+        path: mpv
+
   - name: mpv-mpris
     no-autogen: true
     make-install-args:

--- a/mpv
+++ b/mpv
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+ln -snf "$(xdg-user-dir PICTURES)" "$HOME/.var/app/io.mpv.Mpv/Pictures"
+exec mpv-bin "$@"


### PR DESCRIPTION
Currently mpv can only take a screenshot when user's directories are in English. This little wrapper will symlink `.var/app/io.mpv.Mpv/Pictures` to the `XDG_PICTURES_DIR`. It's a bit hacky, but better than the current situation.

Preferably, XDG user dirs should be added to mpv's config handler to substitute `~~pictures` etc. with an appropriate directory.