### PR TITLE
Move to fsdk 23.08

### DIFF
--- a/io.mpv.Mpv.yml
+++ b/io.mpv.Mpv.yml
@@ -598,8 +598,7 @@ modules:
         sources:
           - type: git
             url: https://github.com/google/shaderc.git
-            tag: v2023.7
-            commit: 3882b16417077aa8eaa7b5775920e7ba4b8a224d
+            commit: 40bced4e1e205ecf44630d2dfa357655b6dabd04
             x-checker-data:
               type: git
               tag-pattern: ^v(\d{4}\.\d{1,2})$

--- a/io.mpv.Mpv.yml
+++ b/io.mpv.Mpv.yml
@@ -1,6 +1,6 @@
 id: io.mpv.Mpv
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 command: mpv
 rename-desktop-file: mpv.desktop


### PR DESCRIPTION
Mesa regression is supposed to be fixed in 23.3.x (which is available in runtime): https://gitlab.freedesktop.org/mesa/mesa/-/issues/9922#note_2113862

Closes https://github.com/flathub/io.mpv.Mpv/pull/300

Closes https://github.com/flathub/io.mpv.Mpv/pull/262