### PR TITLE
Freedeskop 23.08 -> 24.08

### DIFF
--- a/io.mpv.Mpv.yml
+++ b/io.mpv.Mpv.yml
@@ -1,6 +1,6 @@
 id: io.mpv.Mpv
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 command: mpv
 rename-desktop-file: mpv.desktop
@@ -298,6 +298,23 @@ modules:
           version-pattern: The latest version of <code>libdvdnav</code> is <b>([\d\-\.]+)</b>\.
           url-template: https://download.videolan.org/pub/videolan/libdvdnav/$version/libdvdnav-$version.tar.bz2
 
+  # libgcrypt-1.10.3 build fails with freedeskop 24.08
+  - name: libgcrypt
+    config-opts:
+      - --disable-static
+      - --disable-doc
+    sources:
+      - type: git
+        url: https://dev.gnupg.org/source/libgcrypt.git
+        tag: libgcrypt-1.10.3
+        commit: aa1610866f8e42bdc272584f0a717f32ee050a22
+        x-checker-data:
+          type: anitya
+          project-id: 1623
+          stable-only: true
+          tag-template: libgcrypt-$version
+
+          
   - name: libaacs
     config-opts:
       - --disable-static
@@ -635,8 +652,8 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/vapoursynth/vapoursynth/archive/R60.tar.gz
-        sha256: d0ff9b7d88d4b944d35dd7743d72ffcea5faa687f6157b160f57be45f4403a30
+        url: https://github.com/vapoursynth/vapoursynth/archive/refs/tags/R70.tar.gz
+        sha256: 59c813ec36046be33812408ff00e16cae63c6843af6acf4e34595910a80e267b
         x-checker-data:
           type: anitya
           project-id: 15982


### PR DESCRIPTION
libgcrypt downgraded to 1.10.3 (to build for freedesktop 24.08)
vapoursynt R60 -> R70 (working flatpak run --command=vspipe io.mpv.Mpv --version)