### PR TITLE
Drop deps that are avalaible in runtime

### DIFF
--- a/io.mpv.Mpv.yml
+++ b/io.mpv.Mpv.yml
@@ -579,12 +579,12 @@ modules:
 #          type: git
 #          tag-pattern: ^v([\d.]+)$
 
-  - name: vulkan-headers
-    buildsystem: cmake-ninja
-    sources:
-      - type: archive
-        url: https://github.com/KhronosGroup/Vulkan-Headers/archive/v1.3.286.tar.gz
-        sha256: a82a6982efe5e603e23505ca19b469e8f3d876fc677c46b7bfb6177f517bf8fe
+#  - name: vulkan-headers
+#    buildsystem: cmake-ninja
+#    sources:
+#      - type: archive
+#        url: https://github.com/KhronosGroup/Vulkan-Headers/archive/v1.3.286.tar.gz
+#        sha256: a82a6982efe5e603e23505ca19b469e8f3d876fc677c46b7bfb6177f517bf8fe
 
   - name: ffmpeg
     cleanup:

--- a/io.mpv.Mpv.yml
+++ b/io.mpv.Mpv.yml
@@ -679,53 +679,53 @@ modules:
         x-checker-data:
           type: git
           tag-pattern: ^v([\d.]+)$
-    modules:
-      - name: shaderc
-        buildsystem: cmake-ninja
-        builddir: true
-        config-opts:
-          - -DSHADERC_SKIP_COPYRIGHT_CHECK=ON
-          - -DSHADERC_SKIP_EXAMPLES=ON
-          - -DSHADERC_SKIP_TESTS=ON
-          - -DSPIRV_SKIP_EXECUTABLES=ON
-          - -DENABLE_GLSLANG_BINARIES=OFF
-        cleanup:
-          - /bin
-          - /include
-          - /lib/cmake
-          - /lib/pkgconfig
-        sources:
-          - type: git
-            url: https://github.com/google/shaderc.git
-            #tag: v2023.7
-            commit: 40bced4e1e205ecf44630d2dfa357655b6dabd04
-            #x-checker-data:
-            #  type: git
-            #  tag-pattern: ^v(\d{4}\.\d{1,2})$
-          - type: git
-            url: https://github.com/KhronosGroup/SPIRV-Tools.git
-            tag: v2024.1
-            commit: 04896c462d9f3f504c99a4698605b6524af813c1
-            dest: third_party/spirv-tools
-            #x-checker-data:
-            #  type: git
-            #  tag-pattern: ^v(\d{4}\.\d{1})$
-          - type: git
-            url: https://github.com/KhronosGroup/SPIRV-Headers.git
-            #tag: sdk-1.3.250.1
-            commit: 4f7b471f1a66b6d06462cd4ba57628cc0cd087d7
-            dest: third_party/spirv-headers
+#    modules:
+#      - name: shaderc
+#        buildsystem: cmake-ninja
+#        builddir: true
+#        config-opts:
+#          - -DSHADERC_SKIP_COPYRIGHT_CHECK=ON
+#          - -DSHADERC_SKIP_EXAMPLES=ON
+#          - -DSHADERC_SKIP_TESTS=ON
+#          - -DSPIRV_SKIP_EXECUTABLES=ON
+#          - -DENABLE_GLSLANG_BINARIES=OFF
+#        cleanup:
+#          - /bin
+#          - /include
+#          - /lib/cmake
+#          - /lib/pkgconfig
+#        sources:
+#          - type: git
+#            url: https://github.com/google/shaderc.git
+#            #tag: v2023.7
+#            commit: 40bced4e1e205ecf44630d2dfa357655b6dabd04
+#            #x-checker-data:
+#            #  type: git
+#            #  tag-pattern: ^v(\d{4}\.\d{1,2})$
+#          - type: git
+#            url: https://github.com/KhronosGroup/SPIRV-Tools.git
+#            tag: v2024.1
+#            commit: 04896c462d9f3f504c99a4698605b6524af813c1
+#            dest: third_party/spirv-tools
+#            #x-checker-data:
+#            #  type: git
+#            #  tag-pattern: ^v(\d{4}\.\d{1})$
+#          - type: git
+#            url: https://github.com/KhronosGroup/SPIRV-Headers.git
+#            #tag: sdk-1.3.250.1
+#            commit: 4f7b471f1a66b6d06462cd4ba57628cc0cd087d7
+#            dest: third_party/spirv-headers
             #x-checker-data:
             #  type: git
             #  tag-pattern: ^sdk-([\d.]+)$
-          - type: git
-            url: https://github.com/KhronosGroup/glslang.git
-            tag: 15.0.0
-            commit: 46ef757e048e760b46601e6e77ae0cb72c97bd2f
-            dest: third_party/glslang
-            x-checker-data:
-              type: git
-              tag-pattern: ^(\d{1,2}\.\d{1,2}\.\d{1,4})$
+#          - type: git
+#            url: https://github.com/KhronosGroup/glslang.git
+#            tag: 15.0.0
+#            commit: 46ef757e048e760b46601e6e77ae0cb72c97bd2f
+#            dest: third_party/glslang
+#            x-checker-data:
+#              type: git
+#              tag-pattern: ^(\d{1,2}\.\d{1,2}\.\d{1,4})$
 
   - name: mpv
     buildsystem: meson

--- a/io.mpv.Mpv.yml
+++ b/io.mpv.Mpv.yml
@@ -564,20 +564,20 @@ modules:
           - sed -i -e 's/lzma/xz/g' configure.ac
           - autoreconf -vif
 
-  - name: libjxl
-    buildsystem: cmake
-    config-opts:
-      - -DCMAKE_BUILD_TYPE=Release
-      - -DBUILD_TESTING=OFF
-    sources:
-      - type: git
-        url: https://github.com/libjxl/libjxl.git
-        tag: v0.11.0
-        commit: 4df1e9eccdf86b8df4c0c7c08f529263906f9c4f
-        disable-shallow-clone: true
-        x-checker-data:
-          type: git
-          tag-pattern: ^v([\d.]+)$
+#  - name: libjxl
+#    buildsystem: cmake
+#    config-opts:
+#      - -DCMAKE_BUILD_TYPE=Release
+#      - -DBUILD_TESTING=OFF
+#    sources:
+#      - type: git
+#        url: https://github.com/libjxl/libjxl.git
+#        tag: v0.11.0
+#        commit: 4df1e9eccdf86b8df4c0c7c08f529263906f9c4f
+#        disable-shallow-clone: true
+#        x-checker-data:
+#          type: git
+#          tag-pattern: ^v([\d.]+)$
 
   - name: vulkan-headers
     buildsystem: cmake-ninja

--- a/io.mpv.Mpv.yml
+++ b/io.mpv.Mpv.yml
@@ -196,28 +196,28 @@ modules:
           type: git
           tag-pattern: ^(\d\.\d{1,3}\.\d{1,2})$
 
-  - name: libv4l2
-    buildsystem: meson
-    cleanup:
-      - /include
-      - /lib/pkgconfig
-      - /share/man
-    config-opts:
-      - -Ddoxygen-html=false
-      - -Ddoxygen-doc=disabled
-      - -Dbpf=disabled
-      - -Dudevdir=/app/lib/udev
-    sources:
-      - type: git
-        url: https://git.linuxtv.org/v4l-utils.git
-        mirror-urls:
-          - https://github.com/gjasny/v4l-utils.git
-        tag: v4l-utils-1.28.1
-        commit: fc15e229d9d337e46d730f00647821adbbd58548
-        x-checker-data:
-          type: git
-          tag-pattern: ^v4l-utils-([\d.]+)$
-
+#  - name: libv4l2
+#    buildsystem: meson
+#    cleanup:
+#      - /include
+#      - /lib/pkgconfig
+#      - /share/man
+#    config-opts:
+#      - -Ddoxygen-html=false
+#      - -Ddoxygen-doc=disabled
+#      - -Dbpf=disabled
+#      - -Dudevdir=/app/lib/udev
+#    sources:
+#      - type: git
+#        url: https://git.linuxtv.org/v4l-utils.git
+#        mirror-urls:
+#          - https://github.com/gjasny/v4l-utils.git
+#        tag: v4l-utils-1.28.1
+#        commit: fc15e229d9d337e46d730f00647821adbbd58548
+#        x-checker-data:
+#          type: git
+#          tag-pattern: ^v4l-utils-([\d.]+)$
+#
   - name: libcdio
     config-opts:
       - --disable-static


### PR DESCRIPTION
All of those should work ootb in 24.08 runtime. Previously shaderc and some parts of vulkan were missing which created incompatibilities between parts versions shipped in app and in runtime but now it should be finally ok.