### PR TITLE
Disable updates for mujs

### DIFF
--- a/io.mpv.Mpv.yml
+++ b/io.mpv.Mpv.yml
@@ -463,10 +463,11 @@ modules:
         #  - http://git.ghostscript.com/mujs.git
         tag: 1.3.6
         commit: cc569c5fa9a7a2498177693b5617605c2ff5b260
-        x-checker-data:
-          type: git
-          url: https://api.github.com/repos/ccxvii/mujs/tags
-          tag-pattern: ^([\d.]+)$
+        # failing build for 1.3.7
+        #x-checker-data:
+        #  type: git
+        #  url: https://api.github.com/repos/ccxvii/mujs/tags
+        #  tag-pattern: ^([\d.]+)$
 
   - name: nv-codec-headers
     cleanup:


### PR DESCRIPTION
The build is failing with cryptic error. It should be investigated and fixed separately without blocking rest of updates.